### PR TITLE
fix: gif mime type

### DIFF
--- a/patreon_archiver/utils.py
+++ b/patreon_archiver/utils.py
@@ -24,13 +24,15 @@ class UnknownMimetypeError(Exception):
     pass
 
 
-def get_extension(mimetype: str) -> L['png', 'jpg', 'webp']:
+def get_extension(mimetype: str) -> L['png', 'jpg', 'webp', 'gif']:
     if mimetype == 'image/jpeg':
         return 'jpg'
     if mimetype == 'image/png':
         return 'png'
     if mimetype == 'image/webp':
         return 'webp'
+    if mimetype == 'image/gif':
+        return 'gif'
     raise UnknownMimetypeError(mimetype)
 
 


### PR DESCRIPTION
Resolves #124
Previously if the mime type was `image/gif`, the programm would raise an unkown mime type error.
This resolves it by adding the gif mimetype to the allow list.