### PR TITLE
Added TIFF file support.

### DIFF
--- a/patreon_archiver/utils.py
+++ b/patreon_archiver/utils.py
@@ -49,7 +49,7 @@ class UnknownMimetypeError(Exception):
     """Exception raised when an unknown MIME type is encountered."""
 
 
-def _get_extension(mimetype: str) -> Literal['png', 'jpg', 'webp', 'gif']:
+def _get_extension(mimetype: str) -> Literal['png', 'jpg', 'webp', 'gif', 'tif']:
     """
     Get the file extension based on the MIME type.
 
@@ -77,6 +77,8 @@ def _get_extension(mimetype: str) -> Literal['png', 'jpg', 'webp', 'gif']:
             return 'webp'
         case 'image/gif':
             return 'gif'
+        case 'image/tiff':
+            return 'tif'
         case _:
             raise UnknownMimetypeError(mimetype)
 


### PR DESCRIPTION
Hi,
a moment ago, while downloading some images, i got a `patreon_archiver.utils.UnknownMimetypeError: image/tiff` error, so i added support for that, and it went through just fine.

PS: the downloaded file was actually a PNG, but eh, that's the info we're working with.